### PR TITLE
fix(state): clamp addSuperCharge result to non-negative (#39)

### DIFF
--- a/src/lib/game/state.ts
+++ b/src/lib/game/state.ts
@@ -141,10 +141,10 @@ export const gameActions = {
     store.setKey("superCharge", Math.max(0, Math.min(value, max)));
   },
 
-  /** Add super charge (clamped to max) */
+  /** Add super charge (clamped 0 to max) */
   addSuperCharge(amount: number, max: number) {
     const current = store.get().superCharge;
-    store.setKey("superCharge", Math.min(current + amount, max));
+    store.setKey("superCharge", Math.max(0, Math.min(current + amount, max)));
   },
 
   /** Reset super charge to 0 */


### PR DESCRIPTION
Fixes issue #39

## Summary

- Added `Math.max(0, ...)` wrapper to `addSuperCharge` to match `setSuperCharge` validation
- Prevents negative super charge values from breaking UI progress bars

## Test plan

- [ ] Verify super charge bar cannot go below 0 when a negative amount is passed
- [ ] Confirm `setSuperCharge` and `addSuperCharge` now use consistent clamping logic
- [ ] Confirm `juno-dev lint` passes with no new errors