### PR TITLE
fix(chest): add destroy override to clean up animation listener (#29)

### DIFF
--- a/src/lib/game/prefabs/Chest.ts
+++ b/src/lib/game/prefabs/Chest.ts
@@ -70,4 +70,9 @@ export class Chest extends BaseEntity {
     this.removeAllListeners(Phaser.Animations.Events.ANIMATION_COMPLETE);
     super.kill();
   }
+
+  destroy(fromScene?: boolean) {
+    this.removeAllListeners(Phaser.Animations.Events.ANIMATION_COMPLETE);
+    super.destroy(fromScene);
+  }
 }


### PR DESCRIPTION
Fixes issue #29

## Summary

- Added `destroy(fromScene?)` override to `Chest` that removes `ANIMATION_COMPLETE` listeners before calling `super.destroy()`
- Prevents listener leak when Phaser destroys the chest directly during scene shutdown (bypassing `kill()`)

## Test plan

- [ ] Verify no animation listener leaks after scene shutdown with an opened chest
- [ ] Verify `kill()` still works correctly for normal chest cleanup
- [ ] Confirm `juno-dev lint` passes with no new errors