### PR TITLE
fix(boss): add RNG null guard in attack selection (#26)

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "TRESR Game",
   "short_name": "TRESR",
-  "description": "Collect Keys. Fight Enemies. Claim the TRESR.",
+  "description": "Collect Keys. Fight Enemies. Claim the $TRESR.",
   "start_url": "/",
   "display": "fullscreen",
   "background_color": "#0d0a14",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "TRESR Game",
   "short_name": "TRESR",
-  "description": "Collect Keys. Fight Enemies. Claim the $TRESR.",
+  "description": "Collect Keys. Fight Enemies. Claim the TRESR.",
   "start_url": "/",
   "display": "fullscreen",
   "background_color": "#0d0a14",

--- a/src/lib/game/prefabs/Boss.ts
+++ b/src/lib/game/prefabs/Boss.ts
@@ -223,8 +223,8 @@ export class Boss extends BaseEntity {
       "summon",
     ];
     // Seeded random pick for replay determinism (ticket #194)
-    this.currentAttack =
-      attacks[this.rng.integerInRange(0, attacks.length - 1)];
+    const idx = this.rng ? this.rng.integerInRange(0, attacks.length - 1) : 0;
+    this.currentAttack = attacks[idx];
     this.attackTimer = 0;
 
     const bossConfig = this.config.gameplay.entities.boss;


### PR DESCRIPTION
Fixes issue #26

## Summary

- Added null guard for `this.rng` in `selectAttack()` — falls back to index 0 (`ground_pound`) if RNG is unavailable
- Prevents unrecoverable crash if Boss is ever constructed or respawned without an RNG instance

## Test plan

- [ ] Verify boss attack selection works normally with RNG provided
- [ ] Verify no crash if RNG were null (defensive guard)
- [ ] Confirm `juno-dev lint` passes with no new errors