### PR TITLE
fix(super-projectile): add groundY type guards for collision checks (#28)

### DIFF
--- a/src/lib/game/prefabs/SuperProjectile.ts
+++ b/src/lib/game/prefabs/SuperProjectile.ts
@@ -132,6 +132,7 @@ export class SuperProjectile extends Phaser.Physics.Arcade.Sprite {
         const enemy = child as Enemy;
         if (!enemy.active || enemy.hp <= 0) continue;
         if (this.piercedEnemies.has(enemy)) continue;
+        if (typeof enemy.groundY !== "number") continue;
 
         const hDist = Math.abs(this.x - enemy.x);
         const dDist = Math.abs(this.projectileGroundY - enemy.groundY);
@@ -151,7 +152,12 @@ export class SuperProjectile extends Phaser.Physics.Arcade.Sprite {
     }
 
     // Explode on boss hit — stops the projectile
-    if (this.bossRef && this.bossRef.active && this.bossRef.hp > 0) {
+    if (
+      this.bossRef &&
+      this.bossRef.active &&
+      this.bossRef.hp > 0 &&
+      typeof this.bossRef.groundY === "number"
+    ) {
       const hDist = Math.abs(this.x - this.bossRef.x);
       const dDist = Math.abs(this.projectileGroundY - this.bossRef.groundY);
 


### PR DESCRIPTION
Fixes issue #28

## Summary

- Added `typeof enemy.groundY !== "number"` guard before enemy collision distance calculation
- Added `typeof this.bossRef.groundY === "number"` guard before boss collision distance calculation
- Prevents `NaN` from corrupted groundY causing silent collision detection failure

## Test plan

- [ ] Verify super projectile still damages enemies on direct hit
- [ ] Verify super projectile still damages boss on direct hit
- [ ] Verify no crash if an entity has undefined groundY
- [ ] Confirm `juno-dev lint` passes with no new errors