### PR TITLE
fix: remove dev version bumping and sync Cargo.lock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,3 +23,23 @@ juno-dev deploy     # Build and deploy to local satellite
 juno-dev agent-docs # Download AI agent documentation
 juno-dev lint       # Run linter
 ```
+
+## Running Commands in Devenv
+
+**ALL commands MUST be run inside `devenv shell`.** Tools like `cargo`, `bun`, `gh`, `git` (with pre-commit hooks), `juno`, and `solidity-check` are only available inside the devenv environment.
+
+Due to 1Password/secretspec being unavailable in the AI agent sandbox, use this pattern:
+
+```bash
+# Single command
+SECRETSPEC_PROVIDER=env devenv shell --quiet -- <command>
+
+# Examples
+SECRETSPEC_PROVIDER=env devenv shell --quiet -- cargo check
+SECRETSPEC_PROVIDER=env devenv shell --quiet -- juno-dev build-functions
+SECRETSPEC_PROVIDER=env devenv shell --quiet -- git commit -m "feat: add feature"
+SECRETSPEC_PROVIDER=env devenv shell --quiet -- gh pr create --base trunk --title "fix: something"
+SECRETSPEC_PROVIDER=env devenv shell --quiet -- devenv test
+```
+
+> **WARNING:** Running commands outside devenv will cause failures (missing binaries, broken pre-commit hooks, etc.)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,7 +1725,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "satellite"
-version = "0.0.0-dev.1"
+version = "0.0.0"
 dependencies = [
  "candid",
  "hex",

--- a/bin/version.ts
+++ b/bin/version.ts
@@ -56,26 +56,6 @@ function setVersion(targetVersion: string): void {
   log.info(COMPONENT_NAME, `Version set to ${targetVersion}`);
 }
 
-function getCurrentVersionFromFile(): string {
-  const pkgPath = path.join(projectRoot, "package.json");
-  const content = fs.readFileSync(pkgPath, "utf8");
-  const match = content.match(/"version": "([^"]+)"/);
-  return match?.[1] ?? BASE_VERSION;
-}
-
-function devBump(): void {
-  const current = getCurrentVersionFromFile();
-  const devMatch = current.match(/^(.+)-dev\.(\d+)$/);
-  let nextNum: number;
-  if (devMatch) {
-    nextNum = parseInt(devMatch[2], 10) + 1;
-  } else {
-    nextNum = 1;
-  }
-  const devVersion = `${BASE_VERSION}-dev.${nextNum}`;
-  setVersion(devVersion);
-}
-
 const args: string[] = process.argv.slice(2);
 const mode: string | undefined = args[0];
 
@@ -94,8 +74,6 @@ if (mode === "--bump") {
     }
     process.exit(1);
   }
-} else if (mode === "--dev-bump") {
-  devBump();
 } else if (mode === "--reset") {
   setVersion(BASE_VERSION);
   log.info(COMPONENT_NAME, `Version reset to ${BASE_VERSION}`);
@@ -126,7 +104,7 @@ if (mode === "--bump") {
 } else {
   log.error(
     COMPONENT_NAME,
-    "Usage: bun run bin/version.ts --bump | --dev-bump | --reset | --get | --set <version>"
+    "Usage: bun run bin/version.ts --bump | --reset | --get | --set <version>"
   );
   process.exit(1);
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "version-bump": "bun run bin/version.ts --bump",
     "version-set": "bun run bin/version.ts --set",
     "version-get": "bun run bin/version.ts --get",
-    "version-dev": "bun run bin/version.ts --dev-bump",
     "version-reset": "bun run bin/version.ts --reset",
     "client-config": "bun run bin/client-config.ts",
     "prebuild": "bun run client-config",


### PR DESCRIPTION
## Summary

Remove the `--dev-bump` mode from `bin/version.ts` and `version-dev` npm script. Local development always uses `0.0.0`; real versions come from `convco` conventional commits in CI only.

## Changes

- **`bin/version.ts`** — Removed `devBump()`, `getCurrentVersionFromFile()`, and `--dev-bump` CLI mode
- **`package.json`** — Removed `version-dev` npm script
- **`Cargo.lock`** — Fixed stale satellite version from `0.0.0-dev.1` → `0.0.0`

## Root Cause

The dev version bump modified `Cargo.toml`, making `Cargo.lock` stale. This caused:
- `cargo-check` pre-commit hook to fail with "files were modified"
- `juno functions build --locked` to fail in CI

## Versioning Strategy

| Environment | Version Source |
|---|---|
| Local dev | Always `0.0.0` (enforced by `version-reset` pre-commit hook) |
| CI testnet | `convco version --bump` (from conventional commits) |
| CI mainnet | Explicit from release tag |

## Verification

`devenv test` passes — all 5 tasks succeeded.