### PR TITLE
fix(ci): grant reusable workflow permissions in cd-release

### DIFF
--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -52,6 +52,9 @@ concurrency:
 
 permissions:
   contents: write
+  packages: read
+  pull-requests: read
+  statuses: write
 
 env:
   NIXPKGS_ALLOW_UNFREE: 1


### PR DESCRIPTION
## Problem

`cd-release.yaml` calls `cd-juno-testnet.yaml` and `cd-juno-mainnet.yaml` as reusable workflows (`workflow_call`). Called workflows inherit permissions from the caller — but the caller only granted `contents: write`.

The called workflows need `packages: read`, `pull-requests: read`, and `statuses: write`, causing this error:

> The workflow is requesting packages: read, pull-requests: read, statuses: write, but is only allowed packages: none, pull-requests: none, statuses: none.

## Fix

Added the missing permissions to `cd-release.yaml`:

```diff
 permissions:
   contents: write
+  packages: read
+  pull-requests: read
+  statuses: write
```

## Audit

All 12 workflow files were reviewed. Only `cd-release.yaml` had insufficient permissions — all other workflows already declare what they need.