### PR TITLE
fix(ci): resolve concurrency deadlock, permissions, and deploy checks

### DIFF
--- a/.github/workflows/cd-foundry.yaml
+++ b/.github/workflows/cd-foundry.yaml
@@ -61,6 +61,26 @@ jobs:
     environment: ${{ github.event_name == 'push' && 'Testnet' || github.event.inputs.environment }}
 
     steps:
+      - id: check_vars
+        name: Check Variables
+        env:
+          DEPLOYER_PRIVATE_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
+          SNOWTRACE_API_KEY: ${{ secrets.SNOWTRACE_API_KEY }}
+        run: |
+          REQUIRED_VARS=(
+            DEPLOYER_PRIVATE_KEY
+            SNOWTRACE_API_KEY
+          )
+          for VAR in "${REQUIRED_VARS[@]}";
+          do
+            if [[ -z "${!VAR}" ]];
+            then
+              echo "::error::Required variable $VAR is not set"
+              exit 1
+            fi
+          done
+          echo "All required variables are set"
+
       - id: checkout_repository
         name: Checkout Repository
         uses: actions/checkout@v6
@@ -101,6 +121,31 @@ jobs:
             echo "ORACLE_ADDRESS=$(yq ".client.blockchain.avalanche.${NETWORK}.oracle_address" config/tresr.yaml)"
             echo "ADMIN_ADDRESS=$(yq ".client.blockchain.avalanche.${NETWORK}.safe_address" config/tresr.yaml)"
           } >> "$GITHUB_OUTPUT"
+
+      - id: validate_config
+        name: Validate Config
+        env:
+          RPC_URL: ${{ steps.read_config.outputs.RPC_URL }}
+          CHAIN_ID: ${{ steps.read_config.outputs.CHAIN_ID }}
+          TOKEN_ADDRESS: ${{ steps.read_config.outputs.TOKEN_ADDRESS }}
+          ORACLE_ADDRESS: ${{ steps.read_config.outputs.ORACLE_ADDRESS }}
+          ADMIN_ADDRESS: ${{ steps.read_config.outputs.ADMIN_ADDRESS }}
+        run: |
+          ERRORS=0
+          for VAR in RPC_URL CHAIN_ID TOKEN_ADDRESS ORACLE_ADDRESS ADMIN_ADDRESS; do
+            VAL="${!VAR}"
+            if [[ -z "$VAL" || "$VAL" == "null" ]]; then
+              echo "::error::Config value $VAR is empty or null"
+              ERRORS=$((ERRORS + 1))
+            else
+              echo "✓ $VAR=$VAL"
+            fi
+          done
+
+          if [[ $ERRORS -gt 0 ]]; then
+            echo "::error::$ERRORS config value(s) missing. Check tresr.yaml paths."
+            exit 1
+          fi
 
       - id: build_contracts
         name: Build Contracts

--- a/.github/workflows/cd-juno-mainnet.yaml
+++ b/.github/workflows/cd-juno-mainnet.yaml
@@ -19,7 +19,7 @@ on:
         default: ""
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: juno-mainnet-deploy-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/cd-juno-testnet.yaml
+++ b/.github/workflows/cd-juno-testnet.yaml
@@ -19,7 +19,7 @@ on:
         default: ""
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: juno-testnet-deploy-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
## Problem

Three CI/CD issues:

1. **Concurrency deadlock** in Release workflow — `cd-juno-testnet.yaml` and `cd-juno-mainnet.yaml` use `${{ github.workflow }}` in their concurrency group, but when called via `workflow_call`, this resolves to the **caller** name ("Release"), causing parent and child to share the same group → deadlock.

2. **Missing permissions** in `cd-release.yaml` — only granted `contents: write`, but called workflows need `packages: read`, `pull-requests: read`, `statuses: write`, and `actions: write` (for cache).

3. **Cryptic deploy failures** in `cd-foundry.yaml` — `forge script` fails with `No such file or directory (os error 2)` when secrets are missing, with no indication of what is actually wrong.

## Changes

### Concurrency deadlock fix
- `cd-juno-testnet.yaml`: `group: juno-testnet-deploy-${{ github.ref }}`
- `cd-juno-mainnet.yaml`: `group: juno-mainnet-deploy-${{ github.ref }}`

### Permissions
- `cd-release.yaml`: Added `actions: write`, `packages: read`, `pull-requests: read`, `statuses: write`

### Concurrency strategy
- CI workflows (`ci-*`, `sec-*`): `cancel-in-progress: true` (only test latest commit)
- CD workflows (`cd-*`): `cancel-in-progress: false` (queue/train-style, never cancel a deploy)

### Deploy validation
- `cd-foundry.yaml`: Added `check_vars` step (validates secrets before checkout) and `validate_config` step (validates tresr.yaml config values)

### Dependabot
- Changed all commit-message prefixes from ecosystem names to `chore(deps)` for conventional commits