### PR TITLE
fix(game): align Key and Bomb Z-axis integration order with BaseEntity (#95)

### DIFF
--- a/src/lib/game/prefabs/Bomb.ts
+++ b/src/lib/game/prefabs/Bomb.ts
@@ -96,8 +96,8 @@ export class Bomb extends BaseEntity {
     // --- Z-axis falling (inline, not via BaseEntity.updateZ) ---
     // We inline this so we can skip the Arcade body sync entirely.
     if (this.z > 0) {
-      this.vz -= this.gravity; // gravity pulls down
-      this.z += this.vz;
+      this.z += this.vz; // update position first (Symplectic Euler)
+      this.vz -= this.gravity; // then apply gravity
 
       if (this.z <= 0) {
         this.z = 0;

--- a/src/lib/game/prefabs/Key.ts
+++ b/src/lib/game/prefabs/Key.ts
@@ -54,8 +54,8 @@ export class Key extends BaseEntity {
 
     // --- Z-axis falling (inline, not via BaseEntity.updateZ) ---
     if (this.z > 0 || this.vz !== 0) {
-      this.vz -= this.gravity;
       this.z += this.vz;
+      this.vz -= this.gravity;
 
       if (this.z <= 0) {
         this.z = 0;


### PR DESCRIPTION
## Summary

- Swap Key and Bomb Z-axis integration to position-first (Symplectic Euler), matching `BaseEntity.updateZ()`
- Ensures consistent physics across all falling entities

Fixes #95