### PR TITLE
fix(game): gate retardio wander RNG behind jitterTime timer (#94)

### DIFF
--- a/src/lib/game/prefabs/Enemy.ts
+++ b/src/lib/game/prefabs/Enemy.ts
@@ -317,9 +317,12 @@ export class Enemy extends BaseEntity {
           this.play(this.animKeys.walk, true);
         }
       } else {
-        // No enemies nearby — wander erratically
-        this.setFlipX(this.rng.frac() < 0.5);
-        this.setVelocityX((this.rng.frac() - 0.5) * this.speed);
+        // No enemies nearby — wander erratically (timer-gated like erratic AI)
+        if (this.aiTimer > jitterTime) {
+          this.setFlipX(this.rng.frac() < 0.5);
+          this.setVelocityX((this.rng.frac() - 0.5) * this.speed);
+          this.aiTimer = 0;
+        }
         this.setVelocityY(0);
         this.play(this.animKeys.walk, true);
       }


### PR DESCRIPTION
## Summary

- Gate retardio wander mode's flip/velocity randomization behind `jitterTime` timer
- RNG consumed only when `aiTimer > jitterTime`, matching the erratic AI pattern
- Prevents per-frame RNG overconsumption and visual jittering

Fixes #94