### PR TITLE
chore(wallet): deduplicate getEnvironmentKey into config/constants (#97)

### DIFF
--- a/src/lib/config/constants.ts
+++ b/src/lib/config/constants.ts
@@ -49,3 +49,14 @@ export const IC_HOST =
   JUNO_ENVIRONMENT === "development"
     ? `http://127.0.0.1:${JUNO_EMULATOR_PORT}`
     : "https://ic0.app";
+
+/**
+ * Get the environment key for blockchain config lookup.
+ */
+export function getEnvironmentKey(): "anvil" | "testnet" | "mainnet" {
+  return JUNO_ENVIRONMENT === "development"
+    ? "anvil"
+    : JUNO_ENVIRONMENT === "staging"
+      ? "testnet"
+      : "mainnet";
+}

--- a/src/lib/wallet/appkit.ts
+++ b/src/lib/wallet/appkit.ts
@@ -12,7 +12,7 @@ import {WagmiAdapter} from "@reown/appkit-adapter-wagmi";
 import {defineChain} from "@reown/appkit/networks";
 import type {Config} from "@wagmi/core";
 import {config} from "../config/client";
-import {JUNO_ENVIRONMENT} from "../config/constants";
+import {getEnvironmentKey} from "../config/constants";
 import {trackWalletConnect, trackWalletDisconnect} from "../metrics/analytics";
 import {log} from "../utils/log";
 
@@ -25,17 +25,6 @@ const WALLETCONNECT_PROJECT_ID = import.meta.env
 // Singleton instances
 let appKitInstance: AppKit | null = null;
 let wagmiAdapterInstance: WagmiAdapter | null = null;
-
-/**
- * Get the environment key for config lookup.
- */
-function getEnvironmentKey(): "anvil" | "testnet" | "mainnet" {
-  return JUNO_ENVIRONMENT === "development"
-    ? "anvil"
-    : JUNO_ENVIRONMENT === "staging"
-      ? "testnet"
-      : "mainnet";
-}
 
 /**
  * Build the target network from config using defineChain.

--- a/src/lib/wallet/avalanche.ts
+++ b/src/lib/wallet/avalanche.ts
@@ -1,7 +1,7 @@
 import {encodeFunctionData, type Chain} from "viem";
 import {avalanche} from "viem/chains";
 import {loadConfigAsync} from "../config";
-import {JUNO_ENVIRONMENT} from "../config/constants";
+import {JUNO_ENVIRONMENT, getEnvironmentKey} from "../config/constants";
 import {log} from "../utils/log";
 import {VaultAbi, ERC20Abi} from "./VaultAbi";
 import {getWalletClient} from "./connection";
@@ -45,16 +45,8 @@ export function isVaultDeployed(cfg: {
   return !!addr && addr !== ZERO_ADDRESS;
 }
 
-/**
- * Get the environment key for config lookup.
- */
-export function getEnvironmentKey(): "anvil" | "testnet" | "mainnet" {
-  return JUNO_ENVIRONMENT === "development"
-    ? "anvil"
-    : JUNO_ENVIRONMENT === "staging"
-      ? "testnet"
-      : "mainnet";
-}
+// Re-export for consumers that import from ./avalanche
+export {getEnvironmentKey};
 
 /**
  * Create a public client for read-only operations.

--- a/src/lib/wallet/connection.ts
+++ b/src/lib/wallet/connection.ts
@@ -21,7 +21,7 @@ import {
   isConnected as appKitIsConnected,
 } from "./appkit";
 import {config} from "../config/client";
-import {JUNO_ENVIRONMENT} from "../config/constants";
+import {getEnvironmentKey} from "../config/constants";
 import {log} from "../utils/log";
 
 const COMPONENT_NAME = "Connection";
@@ -40,17 +40,6 @@ export interface WalletConnection {
 function getTargetChainId(): number {
   const envKey = getEnvironmentKey();
   return config.blockchain.avalanche[envKey].chain_id;
-}
-
-/**
- * Get the environment key for config lookup.
- */
-function getEnvironmentKey(): "anvil" | "testnet" | "mainnet" {
-  return JUNO_ENVIRONMENT === "development"
-    ? "anvil"
-    : JUNO_ENVIRONMENT === "staging"
-      ? "testnet"
-      : "mainnet";
 }
 
 /**


### PR DESCRIPTION
## Summary

- Move `getEnvironmentKey()` to `src/lib/config/constants.ts` as the single source of truth
- Remove duplicate definitions from `connection.ts` and `appkit.ts`
- Re-export from `avalanche.ts` for existing consumers (`balance.ts`, `faucet.ts`, `tx.ts`)

Fixes #97