### PR TITLE
fix(pwa): add error handling to service worker install event (#52)

### DIFF
--- a/src/lib/pwa/sw.ts
+++ b/src/lib/pwa/sw.ts
@@ -33,9 +33,14 @@ async function loadPrecacheManifest(): Promise<string[]> {
 self.addEventListener("install", (event: ExtendableEvent) => {
   console.log(`[SW] [INFO] Install event fired (build: ${BUILD_ID})`);
   event.waitUntil(
-    loadPrecacheManifest().then((assets) =>
-      caches.open(CACHE_NAME).then((cache) => cache.addAll(assets))
-    )
+    loadPrecacheManifest()
+      .then((assets) =>
+        caches.open(CACHE_NAME).then((cache) => cache.addAll(assets))
+      )
+      .catch((err) => {
+        console.error("[SW] [ERROR] Install failed:", err);
+        throw err;
+      })
   );
 });
 


### PR DESCRIPTION
## Summary

- Add `.catch()` to SW install event promise chain
- Log error with `console.error` and re-throw to properly fail the installation
- Prevents silent failures from network errors, quota exceeded, or private browsing

Fixes #52