### PR TITLE
fix(game): handle promise rejection in MusicManager auth callback (#37)

### DIFF
--- a/src/lib/game/MusicManager.ts
+++ b/src/lib/game/MusicManager.ts
@@ -97,13 +97,22 @@ class MusicManager {
       window.addEventListener("beforeunload", this.handleBeforeUnload);
 
       this.authUnsubscribe = subscribeToAuth(async (state) => {
-        if (state.isAuthenticated && !state.isGuest && state.user) {
-          await this.loadPreferences(state.user.key);
-        } else if (!this.initialPlayStarted && this.tracks.length > 0) {
-          // Guest or unauthenticated — default to shuffle playback
-          this.initialPlayStarted = true;
-          gameActions.updateMusic({playbackMode: "shuffle"});
-          this.playRandomAfterNarration();
+        try {
+          if (state.isAuthenticated && !state.isGuest && state.user) {
+            await this.loadPreferences(state.user.key);
+          } else if (!this.initialPlayStarted && this.tracks.length > 0) {
+            // Guest or unauthenticated — default to shuffle playback
+            this.initialPlayStarted = true;
+            gameActions.updateMusic({playbackMode: "shuffle"});
+            this.playRandomAfterNarration();
+          }
+        } catch (err) {
+          log.warn(COMPONENT_NAME, "Auth callback failed, falling back:", err);
+          if (!this.initialPlayStarted && this.tracks.length > 0) {
+            this.initialPlayStarted = true;
+            gameActions.updateMusic({playbackMode: "shuffle"});
+            this.playRandomAfterNarration();
+          }
         }
       });
     }


### PR DESCRIPTION
## Summary

- Wrap async `subscribeToAuth` callback body in try/catch
- On error, fall back to guest music behavior (shuffle playback with `playRandomAfterNarration()`)
- Prevents unhandled promise rejection from breaking music initialization

Fixes #37