### PR TITLE
fix(satellite): mark session claimed before returning signature (#54)

### DIFF
--- a/src/satellite/src/lib.rs
+++ b/src/satellite/src/lib.rs
@@ -1336,6 +1336,16 @@ async fn claim_authorize(
     let signature_bytes = hex::decode(sig_clean)
         .map_err(|e| format!("Failed to decode signature hex: {}", e))?;
 
+    // Mark session as claimed to prevent double-claim race
+    let mut claimed_session = session.clone();
+    claimed_session.reward_claimed = true;
+    let claimed_doc = SetDoc {
+        data: encode_doc_data(&claimed_session)?,
+        description: Some("claim_authorize: marked reward_claimed".to_string()),
+        version: session_doc.as_ref().unwrap().version,
+    };
+    set_doc_store(caller, "game_sessions".to_string(), session_id.clone(), claimed_doc)?;
+
     Ok((amount, signature_bytes))
 }
 


### PR DESCRIPTION
## Summary
- Closes #54
- After generating the claim signature, marks the game session as `reward_claimed = true` using `set_doc_store` with optimistic locking before returning
- Prevents double-claim race where multiple signatures could be generated for the same session

## Test plan
- [ ] Verify cargo-check passes
- [ ] Confirm session document is updated with `reward_claimed = true` after claim_authorize completes
- [ ] Verify concurrent claim_authorize calls for same session fail with version conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)