### PR TITLE
fix(game): improve mobile HUD and touch controls (#88)

### DIFF
--- a/src/components/game/HUD.astro
+++ b/src/components/game/HUD.astro
@@ -195,26 +195,8 @@ const timerSec = (timerSeconds % 60).toString().padStart(2, "0");
       </div>
     </div>
 
-    <!-- Right: Theme/Profile Icons Placeholder -->
-    <div class="pointer-events-none flex justify-end opacity-0">
-      <div class="h-10 w-32 rounded-full bg-black/20"></div>
-    </div>
-  </div>
-
-  <!-- Bottom HUD Area: 3-column grid with min-w-0 on sides to guarantee true centering -->
-  <div class="grid w-full grid-cols-3 items-end">
-    <div class="min-w-0"></div>
-
-    <!-- Center: Phase Alerts & Pause Button -->
-    <div class="flex flex-col items-center gap-1 pb-2 sm:gap-2 sm:pb-4">
-      <div
-        id="hud-phase-alert"
-        class="badge badge-primary sm:badge-lg hidden text-[10px] font-bold tracking-widest uppercase sm:text-xs"
-      >
-        BOSS INCOMING
-      </div>
-
-      <!-- Centred Pause Button -->
+    <!-- Right: Pause Button -->
+    <div class="flex justify-end">
       <button
         id="btn-hud-pause"
         class="btn btn-circle btn-primary btn-sm sm:btn-md pointer-events-auto min-h-[48px] min-w-[48px] border-2 border-white/10 shadow-xl"
@@ -231,6 +213,21 @@ const timerSec = (timerSeconds % 60).toString().padStart(2, "0");
           <rect x="14" y="4" width="4" height="16"></rect>
         </svg>
       </button>
+    </div>
+  </div>
+
+  <!-- Bottom HUD Area: 3-column grid with min-w-0 on sides to guarantee true centering -->
+  <div class="grid w-full grid-cols-3 items-end">
+    <div class="min-w-0"></div>
+
+    <!-- Center: Phase Alerts -->
+    <div class="flex flex-col items-center gap-1 pb-2 sm:gap-2 sm:pb-4">
+      <div
+        id="hud-phase-alert"
+        class="badge badge-primary sm:badge-lg hidden text-[10px] font-bold tracking-widest uppercase sm:text-xs"
+      >
+        BOSS INCOMING
+      </div>
     </div>
 
     <!-- Right: Boss HP Bar (only visible during boss phase) -->

--- a/src/components/game/TouchControls.astro
+++ b/src/components/game/TouchControls.astro
@@ -33,7 +33,7 @@
     <!-- Jump button (top) -->
     <button
       id="btn-touch-jump"
-      class="btn btn-circle bg-info/40 border-info/60 h-12 w-12 border text-xs font-bold text-white backdrop-blur-sm active:scale-90 sm:h-14 sm:w-14"
+      class="btn btn-circle bg-info/40 border-info/60 h-14 w-14 border text-xs font-bold text-white backdrop-blur-sm active:scale-90 sm:h-16 sm:w-16"
       aria-label="Jump"
     >
       <svg


### PR DESCRIPTION
## Summary

- Move pause button from bottom-center to top-right corner for better thumb accessibility in landscape mode
- Increase jump touch button size from 48px to 56px (matching attack/super) for consistent touch targets
- HUD already uses icons instead of text labels on mobile, respects safe-area insets, and has 48dp+ touch targets

Fixes #88

## Test plan

- [ ] Verify pause button appears in top-right on both mobile and desktop
- [ ] Verify jump button is same size as attack/super buttons on mobile
- [ ] Verify phase alerts still display correctly in bottom-center
- [ ] Verify safe area insets still respected on notched devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)