### PR TITLE
fix(satellite): validate config hash in claim_authorize (#41)

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -158,6 +158,7 @@ Pickel
 
 # Technical terms
 alnum
+hexdigit
 upserted
 verif
 Graphviz

--- a/src/satellite/build.rs
+++ b/src/satellite/build.rs
@@ -1,4 +1,4 @@
-//! Build script — reads config/tresr.yaml and generates Rust constants.
+//! Build script — reads config/tresr.yaml and server-constants.ts to generate Rust constants.
 //!
 //! Generated file: `$OUT_DIR/generated_config.rs`
 //! Network selection: `SATELLITE_NETWORK` env var (default: "mainnet")
@@ -78,6 +78,7 @@ struct Icp {
 fn main() {
     // Re-run when config changes
     println!("cargo::rerun-if-changed=../../config/tresr.yaml");
+    println!("cargo::rerun-if-changed=../../src/lib/config/server-constants.ts");
     println!("cargo::rerun-if-env-changed=SATELLITE_NETWORK");
 
     // Read config
@@ -93,6 +94,36 @@ fn main() {
     let config: Config = serde_yaml::from_str(&yaml_str).unwrap_or_else(|e| {
         panic!("Failed to parse tresr.yaml: {}", e);
     });
+
+    // Read SERVER_CONFIG_HASH from auto-generated server-constants.ts (#41)
+    let constants_path = Path::new("../../src/lib/config/server-constants.ts");
+    let constants_str = fs::read_to_string(constants_path).unwrap_or_else(|e| {
+        panic!(
+            "Failed to read server-constants.ts at {}: {}",
+            constants_path.display(),
+            e
+        )
+    });
+    let config_hash = constants_str
+        .lines()
+        .find_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.starts_with("export const SERVER_CONFIG_HASH") {
+                // Extract hex string between quotes
+                trimmed.split('"').nth(1)
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| {
+            panic!("SERVER_CONFIG_HASH not found in server-constants.ts")
+        });
+    // Validate it looks like a SHA-256 hex digest
+    assert!(
+        config_hash.len() == 64 && config_hash.chars().all(|c| c.is_ascii_hexdigit()),
+        "SERVER_CONFIG_HASH is not a valid 64-char hex string: '{}'",
+        config_hash
+    );
 
     // Select network (default: mainnet)
     let network = env::var("SATELLITE_NETWORK").unwrap_or_else(|_| "mainnet".to_string());
@@ -170,6 +201,9 @@ pub const CONSOLATION_PRIZE_MAX: u64 = {consolation_prize_max};
 
 /// Minimum games played to qualify for consolation prize (from server.highscore.consolation_prize_min_games)
 pub const CONSOLATION_PRIZE_MIN_GAMES: u64 = {consolation_prize_min_games};
+
+/// SHA-256 config hash for anti-cheat validation (from server-constants.ts, ticket #41)
+pub const CONFIG_HASH: &str = "{config_hash}";
 "#,
         network = network,
         ban_durations = ban_durations,
@@ -187,6 +221,7 @@ pub const CONSOLATION_PRIZE_MIN_GAMES: u64 = {consolation_prize_min_games};
         consolation_prize_percent = config.server.highscore.consolation_prize_percent,
         consolation_prize_max = config.server.highscore.consolation_prize_max,
         consolation_prize_min_games = config.server.highscore.consolation_prize_min_games,
+        config_hash = config_hash,
     );
 
     // Write to OUT_DIR

--- a/src/satellite/src/lib.rs
+++ b/src/satellite/src/lib.rs
@@ -1486,7 +1486,42 @@ async fn claim_authorize(
         _ => return Err("No linked EVM wallet".to_string()),
     };
 
-    // 1. Fetch session from Datastore
+    // 1a. Validate config hash from replay payload (#41)
+    let client_config_hash = extract_config_hash(&replay_inputs).map_err(|e| {
+        logging::log_error(
+            "AntiCheat",
+            &format!("Failed to parse replay payload for user {}: {}", caller_text, e),
+        );
+        format!("Invalid replay payload: {}", e)
+    })?;
+
+    if client_config_hash != config::CONFIG_HASH {
+        // Config tampered — apply ban
+        apply_ban(&mut user_profile);
+        let ban_doc = SetDoc {
+            data: encode_doc_data(&user_profile)?,
+            description: Some("Ban applied: config hash mismatch".to_string()),
+            version: user_doc_version,
+        };
+        set_doc_store(caller, "users".to_string(), caller_text.clone(), ban_doc)?;
+
+        logging::log_error(
+            "AntiCheat",
+            &format!(
+                "CHEAT_DETECTED: config hash mismatch for user {}. Expected={}, got={}. Offence #{}, banned_until={:?}",
+                caller_text, config::CONFIG_HASH, client_config_hash,
+                user_profile.offence_count, user_profile.banned_until
+            ),
+        );
+
+        return Err(format!(
+            "CHEAT_DETECTED: Config hash mismatch. Offence #{}, banned_until={}",
+            user_profile.offence_count,
+            user_profile.banned_until.unwrap_or(0)
+        ));
+    }
+
+    // 1b. Fetch session from Datastore
     let session_doc = get_doc_store(caller, "game_sessions".to_string(), session_id.clone())?;
     let session: GameSession = match session_doc {
         Some(ref doc) => decode_doc_data(&doc.data)?,
@@ -1655,6 +1690,47 @@ async fn replay_verify_stub(
     boss_defeated: bool,
 ) -> Result<(u64, bool), String> {
     Ok((reported_keys, boss_defeated))
+}
+
+/// Parse the binary replay payload to extract the config hash (#41).
+///
+/// Payload format (length-prefixed, built by MainScene):
+///   [4 bytes input length (big-endian)][inputs][configHash (64 UTF-8 bytes)][4 bytes seed length][seed]
+///
+/// Returns the config hash as a UTF-8 string, or an error if the payload is malformed.
+fn extract_config_hash(payload: &[u8]) -> Result<String, String> {
+    // Need at least 4 bytes for input length prefix
+    if payload.len() < 4 {
+        return Err("Payload too short: missing input length".to_string());
+    }
+
+    let input_len = u32::from_be_bytes(
+        payload[0..4]
+            .try_into()
+            .map_err(|_| "Failed to read input length")?,
+    ) as usize;
+
+    let hash_start = 4 + input_len;
+    // Config hash is a 64-char hex SHA-256 digest (64 UTF-8 bytes)
+    let hash_end = hash_start + 64;
+    if payload.len() < hash_end {
+        return Err(format!(
+            "Payload too short for config hash: need {} bytes, have {}",
+            hash_end,
+            payload.len()
+        ));
+    }
+
+    let hash_bytes = &payload[hash_start..hash_end];
+    let hash_str =
+        std::str::from_utf8(hash_bytes).map_err(|_| "Config hash is not valid UTF-8")?;
+
+    // Validate hex format
+    if !hash_str.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err("Config hash contains non-hex characters".to_string());
+    }
+
+    Ok(hash_str.to_string())
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Fixes #41

- Modify `build.rs` to read `SERVER_CONFIG_HASH` from `server-constants.ts` and embed it as `config::CONFIG_HASH` at compile time
- Add `extract_config_hash()` helper to parse the binary replay payload and extract the 64-char SHA-256 hex digest
- Add config hash validation in `claim_authorize()` before session fetch — rejects and bans users with mismatched config hashes
- Add "hexdigit" to project spell-check dictionary

## Test plan

- [ ] Run `cargo check --manifest-path src/satellite/Cargo.toml` — compiles without errors
- [ ] Verify `build.rs` correctly reads and validates the hash from `server-constants.ts`
- [ ] Verify `extract_config_hash()` correctly parses the binary payload format: `[4B input_len][inputs][64B config_hash][4B seed_len][seed]`
- [ ] Verify mismatched config hash triggers ban + rejection
- [ ] Verify valid config hash passes validation
- [ ] Run `juno-dev lint` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)