### PR TITLE
fix: EVM RPC has a new format

### DIFF
--- a/src/satellite/src/evm_rpc.rs
+++ b/src/satellite/src/evm_rpc.rs
@@ -2,9 +2,9 @@
 
 use crate::evm_rpc_types::{
     BlockTag, CallArgs, CallResult as EvmCallResult, EvmRpcCanister, GetTransactionCountArgs,
-    GetTransactionCountResult, GetTransactionReceiptResult, MultiCallResult,
-    MultiGetTransactionCountResult, MultiGetTransactionReceiptResult, RequestResult, RpcApi,
-    RpcConfig, RpcService, RpcServices, TransactionRequest,
+    GetTransactionCountResult, GetTransactionReceiptResult, JsonRequestResult, MultiCallResult,
+    MultiGetTransactionCountResult, MultiGetTransactionReceiptResult, MultiJsonRequestResult,
+    RpcApi, RpcConfig, RpcServices, TransactionRequest,
 };
 use candid::Principal;
 use ic_cdk::management_canister::{
@@ -93,7 +93,8 @@ fn default_rpc_config() -> Option<RpcConfig> {
 // Helper: raw JSON-RPC via multi_request (for methods without typed bindings)
 // ---------------------------------------------------------------------------
 
-/// Send a raw JSON-RPC call through the EVM RPC canister's `request` method.
+/// Send a raw JSON-RPC call through the EVM RPC canister's `multi_request` method.
+/// Uses all configured Avalanche RPC URLs for multi-provider consensus.
 /// Used for methods that don't have typed bindings in evm-rpc-canister-types
 /// (e.g. eth_getTransactionByHash, eth_gasPrice, eth_estimateGas).
 async fn json_rpc_request(method: &str, params: &str) -> Result<String, String> {
@@ -104,18 +105,29 @@ async fn json_rpc_request(method: &str, params: &str) -> Result<String, String> 
         method, params
     );
 
-    let service = RpcService::Custom(RpcApi {
-        url: crate::config::AVALANCHE_RPC_URLS[0].to_string(),
-        headers: None,
-    });
-
     let result = canister
-        .request(service, json_body, 2048, cycles_for_call(2048))
+        .multi_request(
+            avalanche_rpc_services(),
+            default_rpc_config(),
+            json_body,
+            cycles_for_call(2048),
+        )
         .await?;
 
     match result.0 {
-        RequestResult::Ok(body) => Ok(body),
-        RequestResult::Err(e) => Err(format!("RPC request error: {:?}", e)),
+        MultiJsonRequestResult::Consistent(JsonRequestResult::Ok(body)) => Ok(body),
+        MultiJsonRequestResult::Consistent(JsonRequestResult::Err(e)) => {
+            Err(format!("RPC request error: {:?}", e))
+        }
+        MultiJsonRequestResult::Inconsistent(results) => Err(format!(
+            "Inconsistent JSON-RPC results from {} providers: {:?}",
+            results.len(),
+            results
+                .into_iter()
+                .map(|(svc, r)| format!("{:?}: {:?}", svc, r))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
     }
 }
 

--- a/src/satellite/src/evm_rpc_types.rs
+++ b/src/satellite/src/evm_rpc_types.rs
@@ -1,11 +1,13 @@
-//! Vendored types from `evm-rpc-canister-types` v5.0.1
+//! Vendored types from `evm-rpc-canister-types` — synced with live canister
+//! `7hfb6-caaaa-aaaar-qadga-cai` Candid interface (2025).
 //!
 //! The upstream crate depends on `ic-cdk ^0.14` which conflicts with our
 //! `ic-cdk 0.19`. The only runtime dependency is the inter-canister call
 //! mechanism, which changed from `call_with_payment128` (0.14) to the builder
-//! `Call` API (0.19). All Candid types are identical.
+//! `Call` API (0.19). All Candid types are kept in sync with the live canister
+//! Candid spec at `candid/evm_rpc.did` in the upstream repository.
 //!
-//! Source: <https://github.com/letmejustputthishere/chain-fusion-starter>
+//! Source: <https://github.com/internet-computer-protocol/evm-rpc-canister>
 //! License: Apache-2.0
 
 #![allow(non_snake_case, clippy::large_enum_variant, dead_code)]
@@ -221,6 +223,22 @@ pub enum RequestCostResult {
     Err(RpcError),
 }
 
+/// Result for a single-provider `multi_request` / `json_request` call.
+/// Mirrors `JsonRequestResult` in the upstream Candid spec.
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub enum JsonRequestResult {
+    Ok(String),
+    Err(RpcError),
+}
+
+/// Result for the multi-provider `multi_request` endpoint.
+/// Mirrors `MultiJsonRequestResult` in the upstream Candid spec.
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub enum MultiJsonRequestResult {
+    Consistent(JsonRequestResult),
+    Inconsistent(Vec<(RpcService, JsonRequestResult)>),
+}
+
 // ============================================================================
 // Structs
 // ============================================================================
@@ -303,6 +321,8 @@ pub struct LogEntry {
 pub struct TransactionReceipt {
     pub to: Option<String>,
     pub status: Option<candid::Nat>,
+    /// Pre-EIP-658 state root (None for EIP-658 chains that use `status`).
+    pub root: Option<String>,
     pub transactionHash: String,
     pub blockNumber: candid::Nat,
     pub from: String,
@@ -314,6 +334,8 @@ pub struct TransactionReceipt {
     pub logsBloom: String,
     pub contractAddress: Option<String>,
     pub gasUsed: candid::Nat,
+    /// Total gas used in the block up to and including this transaction.
+    pub cumulativeGasUsed: candid::Nat,
 }
 
 // ============================================================================
@@ -401,8 +423,32 @@ impl EvmRpcCanister {
             .map_err(|e| format!("{e:?}"))
     }
 
-    // -- single-provider raw JSON-RPC request --------------------------------
+    // -- multi-provider raw JSON-RPC request (preferred) --------------------
 
+    /// Raw JSON-RPC request sent to multiple providers for consensus.
+    /// This is the current recommended endpoint (replaces the deprecated
+    /// single-provider `request` method).
+    pub async fn multi_request(
+        &self,
+        arg0: RpcServices,
+        arg1: Option<RpcConfig>,
+        arg2: String,
+        cycles: u128,
+    ) -> CanisterCallResult<(MultiJsonRequestResult,)> {
+        Call::unbounded_wait(self.0, "multi_request")
+            .with_args(&(arg0, arg1, arg2))
+            .with_cycles(cycles)
+            .await
+            .map_err(|e| format!("{e:?}"))?
+            .candid::<(MultiJsonRequestResult,)>()
+            .map_err(|e| format!("{e:?}"))
+    }
+
+    // -- single-provider raw JSON-RPC request (DEPRECATED) ------------------
+
+    /// DEPRECATED: Use `multi_request` instead.
+    /// Kept for reference; no longer called from production code.
+    #[allow(dead_code)]
     pub async fn request(
         &self,
         arg0: RpcService,


### PR DESCRIPTION
The EVM canister has a new format. This updates to suit.